### PR TITLE
changing iteritems to items for py2/3 compatibility

### DIFF
--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -10,28 +10,28 @@ Defaults {{ defaults }}
 
 # Command aliases
 {% if sudo_cmndalias is defined %}
-{% for name, alias in sudo_cmndalias.iteritems() %}
+{% for name, alias in sudo_cmndalias.items() %}
 Cmnd_Alias {{ name }} = {{ alias }}
 {% endfor %}
 {% endif %}
 
 # Host aliases
 {% if sudo_hostalias is defined %}
-{% for name, alias in sudo_hostalias.iteritems() %}
+{% for name, alias in sudo_hostalias.items() %}
 Host_Alias {{ name }} = {{ alias }}
 {% endfor %}
 {% endif %}
 
 # User aliases
 {% if sudo_useralias is defined %}
-{% for name, alias in sudo_useralias.iteritems() %}
+{% for name, alias in sudo_useralias.items() %}
 User_Alias {{ name }} = {{ alias }}
 {% endfor %}
 {% endif %}
 
 # Run As aliasses
 {% if sudo_runasalias is defined %}
-{% for name, alias in sudo_runasalias.iteritems() %}
+{% for name, alias in sudo_runasalias.items() %}
 Runas_Alias {{ name }} = {{ alias }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Changing iteritems to items in templates to make compatible with both Python 2 and 3 as per Ansible documentation: https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html